### PR TITLE
fix bug in display results

### DIFF
--- a/index.js
+++ b/index.js
@@ -134,12 +134,12 @@ function calculateFinancialAnalysis(data) {
   console.log(
     "Greatest Increase in Profits/Losses:",
     greatestIncrease.date,
-    "($" + greatestIncrease.amount.toFixed(2) + ")"
+    "($" + greatestIncrease.amount.toFixed() + ")"
   );
   console.log(
     "Greatest Decrease in Profits/Losses:",
     greatestDecrease.date,
-    "($" + greatestDecrease.amount.toFixed(2) + ")"
+    "($" + greatestDecrease.amount.toFixed() + ")"
   );
 }
 


### PR DESCRIPTION
Edited   

console.log(
    "Greatest Increase in Profits/Losses:",
    greatestIncrease.date,
    "($" + greatestIncrease.amount.toFixed() + ")"
  );
  console.log(
    "Greatest Decrease in Profits/Losses:",
    greatestDecrease.date,
    "($" + greatestDecrease.amount.toFixed() + ")"
  );

to remove the .toFixed(2) to .toFixed() so there were no decimal places as per the screenshot & instructions